### PR TITLE
Bump kotlin from 2.0.10 to 2.0.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.20"
 androidGradle = "8.5.2"
-kotlinxKsp = "2.0.10-1.0.24"
+kotlinxKsp = "2.0.20-1.0.24"
 composeBom = "2024.06.00"
 androidxActivity = "1.9.1"
 androidxComposeAlpha = "1.7.0-beta07"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.10"
+kotlin = "2.0.20"
 androidGradle = "8.5.2"
 kotlinxKsp = "2.0.10-1.0.24"
 composeBom = "2024.06.00"


### PR DESCRIPTION
Bumps `kotlin` from 2.0.10 to 2.0.20.

Updates `org.jetbrains.kotlin.plugin.serialization` from 2.0.10 to 2.0.20
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/v2.0.20/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.0.10...v2.0.20)

Updates `org.jetbrains.kotlin.android` from 2.0.10 to 2.0.20
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/v2.0.20/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.0.10...v2.0.20)

Updates `org.jetbrains.kotlin.plugin.compose` from 2.0.10 to 2.0.20
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/v2.0.20/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.0.10...v2.0.20)

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin.plugin.serialization dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin.android dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin.plugin.compose dependency-type: direct:production update-type: version-update:semver-patch ...